### PR TITLE
[EN-5989] Updated TruSTAR's default values

### DIFF
--- a/trustar/trustar.py
+++ b/trustar/trustar.py
@@ -1,9 +1,11 @@
 from __future__ import absolute_import
 import json
+from os import name
 
 from .log import get_logger
 from .indicators import SearchIndicator
 from .submission import Submission
+from .trustar_enums import TruStarUrls
 from .version import __version__
 
 logger = get_logger(__name__)
@@ -12,9 +14,9 @@ logger = get_logger(__name__)
 class TruStar:
 
     DEFAULTS = {
-        "auth_endpoint": "https://api.trustar.co/oauth/token",
-        "api_endpoint": "https://api.trustar.co/api/2.0",
-        "station": "https://station.trustar.co",
+        "auth_endpoint": TruStarUrls.AUTH_TOKEN.value,
+        "api_endpoint": TruStarUrls.API.value,
+        "station": TruStarUrls.STATION.value,
         "client_type": "PYTHON_SDK",
         "client_version": __version__,
         "verify": True,

--- a/trustar/trustar_enums.py
+++ b/trustar/trustar_enums.py
@@ -10,30 +10,39 @@ class TSEnum(Enum):
 
 class SortColumns(TSEnum):
     
-    UPDATED = "UPDATED"
     CREATED = "CREATED"
-    PROCESSED_AT = "PROCESSED_AT"    
+    PROCESSED_AT = "PROCESSED_AT"
+    UPDATED = "UPDATED"
 
 
 class ObservableTypes(TSEnum):
+
+    BITCOIN_ADDRESS = "BITCOIN_ADDRESS"
+    CIDR_BLOCK = "CIDR_BLOCK"
+    EMAIL_ADDRESS = "EMAIL_ADDRESS"
     IP4 = "IP4"
     IP6 = "IP6"
-    URL = "URL"
+    MD5 = "MD5"
+    PHONE_NUMBER = "PHONE_NUMBER"
+    REGISTRY_KEY = "REGISTRY_KEY"
     SHA1 = "SHA1"
     SHA256 = "SHA256"
-    EMAIL_ADDRESS = "EMAIL_ADDRESS"
-    PHONE_NUMBER = "PHONE_NUMBER"
-    MD5 = "MD5"
-    BITCOIN = "BITCOIN"
-    XID = "XID"
-    REGISTRY_KEY = "REGISTRY_KEY"
     SOFTWARE = "SOFTWARE"
-    CIDR_BLOCK = "CIDR_BLOCK"
+    URL = "URL"
+    X_ID = "X_ID"
 
 
 class AttributeTypes(TSEnum):
-    MALWARE = "MALWARE"
+    
     CORA_MALWARE = "CORA_MALWARE"
-    THREAT_ACTOR = "THREAT_ACTOR"
     CVE = "CVE"
+    MALWARE = "MALWARE"
     MITRE_TACTIC = "MITRE_TACTIC"
+    THREAT_ACTOR = "THREAT_ACTOR"
+
+
+class TruStarUrls(TSEnum):
+
+    API = "https://api.trustar.co/api/2.0"
+    AUTH_TOKEN = "https://api.trustar.co/oauth/token"
+    STATION = "https://station.trustar.co"


### PR DESCRIPTION
### `Resolves`:
- [EN-5989](https://trustar.atlassian.net/browse/EN-5989) **Update TruSTAR's enums default values**

### `Brief Description`:

- **WHAT**: Update TruSTAR's enums with default values.

- **HOW**: Update their name and values and add new ones.

- **WHY**: In order to match our currently supported IOCs types and parameterize default URLs.