### PR TITLE
Fix defaults values

### DIFF
--- a/tests/unit/test_submission.py
+++ b/tests/unit/test_submission.py
@@ -17,6 +17,8 @@ def submission():
     )
 
 
+TOTAL_DEFAULT_PARAMS = 1
+
 @pytest.fixture
 def indicators():
     bad_panda = Entity.attribute("MALWARE", "BAD_PANDA")
@@ -36,76 +38,76 @@ def indicators():
 
 
 def test_submission_is_empty(submission):
-    assert len(submission.params) == 0
+    assert len(submission.params) == TOTAL_DEFAULT_PARAMS
 
 
 def test_set_id(submission):
     submission.set_id("TEST_ID")
     params = [p.value for p in submission.params]
-    assert len(submission.params) == 1
-    assert params[0] == "TEST_ID"
+    assert len(submission.params) == TOTAL_DEFAULT_PARAMS + 1
+    assert params[TOTAL_DEFAULT_PARAMS] == "TEST_ID"
 
 
 def test_set_title(submission):
     submission.set_title("TEST_TITLE")
     params = [p.value for p in submission.params]
-    assert len(submission.params) == 1
-    assert params[0] == "TEST_TITLE"
+    assert len(submission.params) == TOTAL_DEFAULT_PARAMS + 1
+    assert params[TOTAL_DEFAULT_PARAMS] == "TEST_TITLE"
 
 
 def test_set_enclave_id(submission):
     submission.set_enclave_id("TEST-ENCLAVE-ID")
     params = [p.value for p in submission.params]
-    assert len(submission.params) == 1
-    assert params[0] == "TEST-ENCLAVE-ID"
+    assert len(submission.params) == TOTAL_DEFAULT_PARAMS + 1
+    assert params[TOTAL_DEFAULT_PARAMS] == "TEST-ENCLAVE-ID"
 
 
 def test_set_external_id(submission):
     submission.set_external_id("TEST-EXTERNAL-ID")
     params = [p.value for p in submission.params]
-    assert len(submission.params) == 1
-    assert params[0] == "TEST-EXTERNAL-ID"
+    assert len(submission.params) == TOTAL_DEFAULT_PARAMS + 1
+    assert params[TOTAL_DEFAULT_PARAMS] == "TEST-EXTERNAL-ID"
 
 
 def test_set_external_url(submission):
     submission.set_external_url("TEST-EXTERNAL-URL")
     params = [p.value for p in submission.params]
-    assert len(submission.params) == 1
-    assert params[0] == "TEST-EXTERNAL-URL"
+    assert len(submission.params) == TOTAL_DEFAULT_PARAMS + 1
+    assert params[TOTAL_DEFAULT_PARAMS] == "TEST-EXTERNAL-URL"
 
 
 def test_set_tags(submission):
     submission.set_tags(["TEST_TAG1", "TEST_TAG2"])
     params = [p.value for p in submission.params]
-    assert len(submission.params) == 1
-    assert params[0] == ["TEST_TAG1", "TEST_TAG2"]
+    assert len(submission.params) == TOTAL_DEFAULT_PARAMS
+    assert params[TOTAL_DEFAULT_PARAMS -1] == ["TEST_TAG1", "TEST_TAG2"]
 
 
 def test_set_include_content(submission):
     submission.set_include_content(True)
     params = [p.value for p in submission.params]
-    assert len(submission.params) == 1
-    assert params[0] == True
+    assert len(submission.params) == TOTAL_DEFAULT_PARAMS + 1
+    assert params[TOTAL_DEFAULT_PARAMS] == True
 
 
 def test_set_content_indicators(submission, indicators):
     submission.set_content_indicators(indicators)
     serialized_indicators = [i.serialize() for i in indicators]
     params = [p.value for p in submission.params]
-    assert params[0]["indicators"] == serialized_indicators
+    assert params[TOTAL_DEFAULT_PARAMS]["indicators"] == serialized_indicators
 
 
 def test_set_raw_content(submission):
     submission.set_raw_content("RAW CONTENT")
     params = [p.value for p in submission.params]
-    assert params[0] == "RAW CONTENT"
+    assert params[TOTAL_DEFAULT_PARAMS] == "RAW CONTENT"
 
 
 @pytest.mark.parametrize("date", [1583960400, "2020-03-11T21:00:00"])
 def test_set_timestamp(submission, date):
     submission.set_timestamp(date)
     assert submission.params.get("timestamp") == 1583960400
-    assert len(submission.params) == 1
+    assert len(submission.params) == TOTAL_DEFAULT_PARAMS + 1
 
 
 def test_create_fails_without_mandatory_fields(submission, indicators):

--- a/trustar/models/indicator.py
+++ b/trustar/models/indicator.py
@@ -47,10 +47,7 @@ class Indicator(Base):
     def serialize(self):
         serialized = {}
         serialized.update(self.observable.serialize())
-        if len(self.attributes):
-            serialized.update({"attributes": [attr.serialize() for attr in self.attributes]})
-        if len(self.related_observables):
-            serialized.update({"relatedObservables": [attr.serialize() for attr in self.related_observables]})
-        if len(self.tags):
-            serialized.update({"tags": self.tags})
+        serialized.update({"attributes": [attr.serialize() for attr in self.attributes] if len(self.attributes) else []})
+        serialized.update({"relatedObservables": [attr.serialize() for attr in self.related_observables] if len(self.related_observables) else []})
+        serialized.update({"tags": self.tags})
         return serialized

--- a/trustar/submission.py
+++ b/trustar/submission.py
@@ -18,6 +18,8 @@ class Submission(object):
     def __init__(self, config):
         self.config = config
         self.params = SubmissionsParamSerializer()
+        for func in (self.set_tags,):
+            func()
 
     @property
     def endpoint(self):
@@ -78,12 +80,14 @@ class Submission(object):
         """
         self.set_custom_param("externalUrl", external_url)
 
-    def set_tags(self, tags):
+    def set_tags(self, tags=None):
         """Adds tags param to set of params.
 
         :param tags: field value.
         :returns: self.
         """
+        if not tags:
+            tags = []
         self.set_custom_param("tags", tags)
 
     def set_include_content(self, content=False):

--- a/trustar/submission.py
+++ b/trustar/submission.py
@@ -118,6 +118,14 @@ class Submission(object):
         """
         self.set_custom_param("rawContent", raw_content)
 
+    def set_submission_version(self, version):
+        """Adds submissionVersion param to set of params.
+
+        :param version: field value.
+        :returns: self.
+        """
+        self.set_custom_param("submissionVersion", version)
+
     @property
     def query_params(self):
         return {


### PR DESCRIPTION
*WHAT*: We need to set some default values initially even as empty

*WHY*: the  backend will cry otherwise

*HOW*: setting defaults value on object creation, or in serialization in some cases

jira: https://trustar.atlassian.net/browse/EN-6082