### PR TITLE
Changing enclaveId to enclaveGuid and defaulting submission config to…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,5 @@ dmypy.json
 .idea
 
 trustar_config.json
+
+.venv*

--- a/tests/unit/resources.py
+++ b/tests/unit/resources.py
@@ -82,7 +82,7 @@ submission_example_request = """
       }
     ]
   },
-  "enclaveId": "c0f07a9f-76e4-48df-a0d4-c63ed2edccf0",
+  "enclaveGuid": "c0f07a9f-76e4-48df-a0d4-c63ed2edccf0",
   "externalId": "external-1234",
   "externalUrl": "externalUrlValue",
   "timestamp": 1607102497,

--- a/trustar/submission.py
+++ b/trustar/submission.py
@@ -12,10 +12,10 @@ class SubmissionsParamSerializer(Params):
 @fluent
 class Submission(object):
 
-    NEW_SUBMISSION_MANDATORY_FIELDS = ("title", "content", "enclaveId")
+    NEW_SUBMISSION_MANDATORY_FIELDS = ("title", "content", "enclaveGuid")
     path = "/submissions/indicators"
 
-    def __init__(self, config):
+    def __init__(self, config=None):
         self.config = config
         self.params = SubmissionsParamSerializer()
         for func in (self.set_tags,):
@@ -62,7 +62,7 @@ class Submission(object):
         :param enclave_id: field value.
         :returns: self.
         """
-        self.set_custom_param("enclaveId", enclave_id)
+        self.set_custom_param("enclaveGuid", enclave_id)
 
     def set_external_id(self, external_id):
         """Adds externalId param to set of params.
@@ -131,7 +131,7 @@ class Submission(object):
         return {
             p.key: p.value
             for p in self.params
-            if p in ("id", "enclaveId", "includeContent")
+            if p in ("id", "enclaveGuid", "includeContent")
         }
 
     def create_query(self, method):


### PR DESCRIPTION
What: Changing enclaveId to enclaveGuid as API changed it too. And setting submission default value to `None`

Why: Changes in API and usability for the SDK in trustash.

How: Renaming and setting default value on code.