### PR TITLE
build wheel on circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,19 +8,11 @@ commands:
           name: Run tests with Python 2.7
           command: |
             sudo pip install --upgrade pip
-            pip install --user tox
+            pip install --user tox tox-wheel
             tox -e py27
-
-  build_python_2_7_wheel:
-    steps:
-      - run:
-        name: Build the python2 wheel
-        when: always
-        command: |
-          python2 setup.py bdist_wheel
       - store_artifacts:
-          path: dist/
-          destination: circleci-wheels
+          path: .tox/dist/
+          destination: circleci-wheels-p27
 
   test_py37:
     steps:
@@ -29,19 +21,11 @@ commands:
           name: Run tests with Python 3.7
           command: |
             sudo pip install --upgrade pip
-            pip install --user tox
+            pip install --user tox tox-wheel
             tox -e py37
-
-  build_python_3_7_wheel:
-    steps:
-      - run:
-        name: Build the python3 wheel
-        command:  |
-          python3 setup.py bdist_wheel
-        when: always
       - store_artifacts:
-          path: dist/
-          destination: circleci-wheels
+          path: .tox/dist/
+          destination: circleci-wheels-p37
 
 executors:
   docker_python_2_7:
@@ -58,14 +42,12 @@ jobs:
     working_directory: ~/project
     steps:
       - test_py27
-      - build_python_2_7_wheel
 
   test_python_3_7_environment:
     executor: docker_python_3_7
     working_directory: ~/project
     steps:
       - test_py37
-      - build_python_3_7_wheel
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,9 @@ commands:
       - run:
         name: Build the python2 wheel
         command: python2 setup.py bdist_wheel
-        - store_artifacts:
-            path: dist/
-            destination: circleci-wheels
+      - store_artifacts:
+          path: dist/
+          destination: circleci-wheels
 
   test_py37:
     steps:
@@ -35,9 +35,9 @@ commands:
       - run:
         name: Build the python3 wheel
         command: python3 setup.py bdist_wheel
-        - store_artifacts:
-            path: dist/
-            destination: circleci-wheels
+      - store_artifacts:
+          path: dist/
+          destination: circleci-wheels
 
 executors:
   docker_python_2_7:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,9 @@ commands:
     steps:
       - run:
         name: Build the python2 wheel
-        command: python2 setup.py bdist_wheel
+        when: always
+        command: |
+          python2 setup.py bdist_wheel
       - store_artifacts:
           path: dist/
           destination: circleci-wheels
@@ -34,7 +36,9 @@ commands:
     steps:
       - run:
         name: Build the python3 wheel
-        command: python3 setup.py bdist_wheel
+        command:  |
+          python3 setup.py bdist_wheel
+        when: always
       - store_artifacts:
           path: dist/
           destination: circleci-wheels

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,15 @@ commands:
             pip install --user tox
             tox -e py27
 
+  build_python_2_7_wheel:
+    steps:
+      - run:
+        name: Build the python2 wheel
+        command: python2 setup.py bdist_wheel
+        - store_artifacts:
+            path: dist/
+            destination: circleci-wheels
+
   test_py37:
     steps:
       - checkout
@@ -20,6 +29,15 @@ commands:
             sudo pip install --upgrade pip
             pip install --user tox
             tox -e py37
+
+  build_python_3_7_wheel:
+    steps:
+      - run:
+        name: Build the python3 wheel
+        command: python3 setup.py bdist_wheel
+        - store_artifacts:
+            path: dist/
+            destination: circleci-wheels
 
 executors:
   docker_python_2_7:
@@ -36,12 +54,14 @@ jobs:
     working_directory: ~/project
     steps:
       - test_py27
+      - build_python_2_7_wheel
 
   test_python_3_7_environment:
     executor: docker_python_3_7
     working_directory: ~/project
     steps:
       - test_py37
+      - build_python_3_7_wheel
 
 workflows:
   version: 2

--- a/setup.py
+++ b/setup.py
@@ -8,14 +8,14 @@ with open("trustar/version.py") as fp:
 version = version_globals['__version__']
 
 setup(
-    name='trustar',
-    packages=find_packages(),
+    name='trustar2',
+    packages=find_packages(exclude=("tests",)),
     version=version,
     author='TruSTAR Technology, Inc.',
     author_email='support@trustar.co',
-    url='https://github.com/trustar/trustar-python',
-    download_url='https://github.com/trustar/trustar-python/tarball/%s' % version,
-    description='Python SDK for the TruSTAR REST API',
+    url='https://github.com/trustar/trustar-sdk2-proto/',
+    download_url='https://github.com/trustar/trustar-sdk2-proto/tarball/%s' % version,
+    description='Python SDK2 for the TruSTAR REST API',
     license='MIT',
     install_requires=['json_log_formatter',
                       'future',
@@ -29,6 +29,5 @@ setup(
                       'six'
                       ],
     include_package_data=True,
-    scripts=glob('trustar/examples/**/*.py') + glob('trustar/examples/*.py'),
     use_2to3=True
 )

--- a/tests/unit/test_submission.py
+++ b/tests/unit/test_submission.py
@@ -45,62 +45,63 @@ def test_set_id(submission):
     submission.set_id("TEST_ID")
     params = [p.value for p in submission.params]
     assert len(submission.params) == TOTAL_DEFAULT_PARAMS + 1
-    assert params[TOTAL_DEFAULT_PARAMS] == "TEST_ID"
+    assert "TEST_ID" in params
 
 
 def test_set_title(submission):
     submission.set_title("TEST_TITLE")
     params = [p.value for p in submission.params]
     assert len(submission.params) == TOTAL_DEFAULT_PARAMS + 1
-    assert params[TOTAL_DEFAULT_PARAMS] == "TEST_TITLE"
+    assert "TEST_TITLE" in params
 
 
 def test_set_enclave_id(submission):
     submission.set_enclave_id("TEST-ENCLAVE-ID")
     params = [p.value for p in submission.params]
     assert len(submission.params) == TOTAL_DEFAULT_PARAMS + 1
-    assert params[TOTAL_DEFAULT_PARAMS] == "TEST-ENCLAVE-ID"
+    assert  "TEST-ENCLAVE-ID" in params
 
 
 def test_set_external_id(submission):
     submission.set_external_id("TEST-EXTERNAL-ID")
     params = [p.value for p in submission.params]
     assert len(submission.params) == TOTAL_DEFAULT_PARAMS + 1
-    assert params[TOTAL_DEFAULT_PARAMS] == "TEST-EXTERNAL-ID"
+    assert "TEST-EXTERNAL-ID" in params
 
 
 def test_set_external_url(submission):
     submission.set_external_url("TEST-EXTERNAL-URL")
     params = [p.value for p in submission.params]
     assert len(submission.params) == TOTAL_DEFAULT_PARAMS + 1
-    assert params[TOTAL_DEFAULT_PARAMS] == "TEST-EXTERNAL-URL"
+    assert "TEST-EXTERNAL-URL" in params
 
 
 def test_set_tags(submission):
     submission.set_tags(["TEST_TAG1", "TEST_TAG2"])
     params = [p.value for p in submission.params]
     assert len(submission.params) == TOTAL_DEFAULT_PARAMS
-    assert params[TOTAL_DEFAULT_PARAMS -1] == ["TEST_TAG1", "TEST_TAG2"]
+    assert ["TEST_TAG1", "TEST_TAG2"] in params
 
 
 def test_set_include_content(submission):
     submission.set_include_content(True)
     params = [p.value for p in submission.params]
     assert len(submission.params) == TOTAL_DEFAULT_PARAMS + 1
-    assert params[TOTAL_DEFAULT_PARAMS] == True
+    assert True in params
 
 
 def test_set_content_indicators(submission, indicators):
     submission.set_content_indicators(indicators)
     serialized_indicators = [i.serialize() for i in indicators]
-    params = [p.value for p in submission.params]
-    assert params[TOTAL_DEFAULT_PARAMS]["indicators"] == serialized_indicators
+    # hacky workaround for python2 unsorted dicts
+    params = [p.value for p in submission.params if p.value != []]
+    assert serialized_indicators == params[0]["indicators"]
 
 
 def test_set_raw_content(submission):
     submission.set_raw_content("RAW CONTENT")
     params = [p.value for p in submission.params]
-    assert params[TOTAL_DEFAULT_PARAMS] == "RAW CONTENT"
+    assert "RAW CONTENT" in params
 
 
 @pytest.mark.parametrize("date", [1583960400, "2020-03-11T21:00:00"])

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@
 envlist = py27,py37
 
 [testenv]
+wheel = true
 deps = 
     pytest
     flake8 


### PR DESCRIPTION
*WHAT*: Creates a whl for python2 and another for python3 in circle-ci

*WHY*: Until we get this package on pipi is comfy to just grab it from circle ci instead of generating one everytime someones needs it

*HOW*: Using TOX and circle ci

ps: Currently circle ci doesn't have a why to easily expose the artifacts to github.

jira: https://trustar.atlassian.net/browse/EN-6096