### PR TITLE
fixed missing param

### DIFF
--- a/trustar/submission.py
+++ b/trustar/submission.py
@@ -131,7 +131,7 @@ class Submission(object):
         return {
             p.key: p.value
             for p in self.params
-            if p in ("id", "enclaveGuid", "includeContent")
+            if p.key in ("id", "enclaveGuid", "includeContent")
         }
 
     def create_query(self, method):


### PR DESCRIPTION
**What?** 
  The `p` obj in a loop in the `query_params()` was missing a call to `.key` which was causing the query params dict to not be populated.

**Why?**
To fix a small bug.

**How?**
Adding a call to the `.key` attribute