### PR TITLE
[EN-6106] Create some helpers to publish the SDK in PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,13 @@ If you want to test all available environments:, just do:
 If you want to run a specific environment:
 
 `tox -e py27` or `tox -e py37`
+
+# Releasing a new version
+
+To publish a new version in PyPI you should use the `release.sh` script that is in the root of the project. Suppose you want to release v0.0.1, you should do:
+
+```
+bash release.sh v0.0.1
+```
+
+Obviously, in order to make a release, you must have permissions to do so and you must have your PyPI creds available for Twine.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,3 +5,4 @@ pytest==4.6.11
 pytest-mock==2.0.0
 requests==2.25.0
 requests-mock==1.8.0
+twine==3.3.0

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,15 @@
+# usage: ./release.sh 0.3.x
+
+VERSION=$1
+
+# validate version parameter passed
+[[ -z "$VERSION" ]] && { echo "VERSION is required" ; exit 1; }
+
+# tag repository
+echo "Tagging $VERSION"
+git tag $VERSION -m "Bump version"
+git push --tags origin master
+
+# package and upload
+echo "Releasing version $VERSION"
+twine upload --skip-existing dist/trustar2-${VERSION}.tar.gz


### PR DESCRIPTION
*What*: This is a helper script to make releases of the SDK in PyPI.

*Why*: This script will avoid some human errors while publishing.

*How*: There is a BASH script that requires a version number as a parameter. It tags the repo, pushes the tags, and then uploads to PyPI using twine.

Here as Jira issue to track this: https://trustar.atlassian.net/browse/EN-6106
