### PR TITLE
now it goes to PyPI

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,3 +6,4 @@ pytest-mock==2.0.0
 requests==2.25.0
 requests-mock==1.8.0
 twine==3.3.0
+sdist

--- a/release.sh
+++ b/release.sh
@@ -10,6 +10,9 @@ echo "Replacing version in trustar/version.py"
 cat > trustar/version.py <<- EOM
 __version__ = "$VERSION"
 EOM
+git add trustar/version.py
+git commit -m "Bump version"
+git push main
 
 # tag repository
 echo "Tagging $VERSION"

--- a/release.sh
+++ b/release.sh
@@ -5,11 +5,18 @@ VERSION=$1
 # validate version parameter passed
 [[ -z "$VERSION" ]] && { echo "VERSION is required" ; exit 1; }
 
+# replace version in file
+echo "Replacing version in trustar/version.py"
+cat > trustar/version.py <<- EOM
+__version__ = "$VERSION"
+EOM
+
 # tag repository
 echo "Tagging $VERSION"
 git tag $VERSION -m "Bump version"
-git push --tags origin master
+git push --tags origin main
 
 # package and upload
 echo "Releasing version $VERSION"
+python setup.py sdist
 twine upload --skip-existing dist/trustar2-${VERSION}.tar.gz

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -2,6 +2,7 @@ import pytest
 
 from trustar.api_client import ApiClient
 from trustar.trustar import TruStar
+from trustar.version import __version__
 
 
 @pytest.fixture
@@ -20,7 +21,7 @@ def test_get_headers(api_client, mocked_request):
         "Authorization": "Bearer TOKEN12345",
         "Client-Metatag": "TEST_METATAG",
         "Client-Type": "PYTHON_SDK",
-        "Client-Version": "1.0.0",
+        "Client-Version": __version__,
         "Content-Type": "application/json",
     }
     assert headers == expected_headers

--- a/trustar/version.py
+++ b/trustar/version.py
@@ -1,2 +1,1 @@
-__version__ = "1.0.0"
-__api_version__ = "2.0"
+__version__ = "0.1"


### PR DESCRIPTION
*what*: some fixes needed to actually upload to pypi

*why*: because we weren't building the package

*how*: added the sdist packaging tool and fixed building in the script