### PR TITLE
bugfix - Fix timestamp being send in seconds instead of miliseconds

### DIFF
--- a/tests/unit/resources.py
+++ b/tests/unit/resources.py
@@ -31,8 +31,8 @@ submission_example_request = """
           "value": "verybadurl",
           "type": "URL"
         },
-        "validFrom": 1604510497,
-        "validTo": 1607102497,
+        "validFrom": 1604510497000,
+        "validTo": 1607102497000,
         "maliciousScore": "BENIGN",
         "confidenceScore": "LOW",
         "attributes": [
@@ -41,8 +41,8 @@ submission_example_request = """
               "value": "ActorName",
               "type": "THREAT_ACTOR"
             },
-            "validFrom": 1604510497,
-            "validTo": 1607102497,
+            "validFrom": 1604510497000,
+            "validTo": 1607102497000,
             "confidenceScore": "LOW"
           },
           {
@@ -50,8 +50,8 @@ submission_example_request = """
               "value": "MalwareName",
               "type": "MALWARE"
             },
-            "validFrom": 1604510497,
-            "validTo": 1607102497,
+            "validFrom": 1604510497000,
+            "validTo": 1607102497000,
             "confidenceScore": "MEDIUM"
           }
         ],
@@ -61,8 +61,8 @@ submission_example_request = """
               "value": "2.2.2.2",
               "type": "IP4"
             },
-            "validFrom": 1604510497,
-            "validTo": 1607102497,
+            "validFrom": 1604510497000,
+            "validTo": 1607102497000,
             "confidenceScore": "LOW"
           },
           {
@@ -70,8 +70,8 @@ submission_example_request = """
               "value": "wwww.relatedUrl.com",
               "type": "URL"
             },
-            "validFrom": 1604510497,
-            "validTo": 1607102497,
+            "validFrom": 1604510497000,
+            "validTo": 1607102497000,
             "confidenceScore": "HIGH"
           }
         ],
@@ -85,7 +85,7 @@ submission_example_request = """
   "enclaveGuid": "c0f07a9f-76e4-48df-a0d4-c63ed2edccf0",
   "externalId": "external-1234",
   "externalUrl": "externalUrlValue",
-  "timestamp": 1607102497,
+  "timestamp": 1607102497000,
   "tags": ["random_tag"],
   "rawContent": "blob of text"
 }

--- a/tests/unit/test_indicators.py
+++ b/tests/unit/test_indicators.py
@@ -28,10 +28,10 @@ def test_set_query_term(search_indicator):
     assert values[0] == "TEST_TERM"
 
 
-@pytest.mark.parametrize("from_date", [1583960400, "2020-03-11T21:00:00"])
+@pytest.mark.parametrize("from_date", [1583960400000, "2020-03-11T21:00:00"])
 def test_set_from(search_indicator, from_date):
     search_indicator.set_from(from_date)
-    assert search_indicator.params.get("from") == 1583960400
+    assert search_indicator.params.get("from") == 1583960400000
     assert len(search_indicator.params) == 1
 
 
@@ -41,10 +41,10 @@ def test_set_from_fail(search_indicator):
     assert len(search_indicator.params) == 0
 
 
-@pytest.mark.parametrize("to_date", [1583960400, "2020-03-11T21:00:00+00:00"])
+@pytest.mark.parametrize("to_date", [1583960400000, "2020-03-11T21:00:00+00:00"])
 def test_set_to(search_indicator, to_date):
     search_indicator.set_to(to_date)
-    assert search_indicator.params.get("to") == 1583960400
+    assert search_indicator.params.get("to") == 1583960400000
     assert len(search_indicator.params) == 1
 
 

--- a/tests/unit/test_submission.py
+++ b/tests/unit/test_submission.py
@@ -104,10 +104,10 @@ def test_set_raw_content(submission):
     assert "RAW CONTENT" in params
 
 
-@pytest.mark.parametrize("date", [1583960400, "2020-03-11T21:00:00"])
+@pytest.mark.parametrize("date", [1583960400000, "2020-03-11T21:00:00"])
 def test_set_timestamp(submission, date):
     submission.set_timestamp(date)
-    assert submission.params.get("timestamp") == 1583960400
+    assert submission.params.get("timestamp") == 1583960400000
     assert len(submission.params) == TOTAL_DEFAULT_PARAMS + 1
 
 
@@ -122,33 +122,33 @@ def test_create_fails_without_mandatory_fields(submission, indicators):
 def complex_indicator():
     threat_actor = (
         Entity.attribute("THREAT_ACTOR", "ActorName")
-        .set_valid_from(1604510497)
-        .set_valid_to(1607102497)
+        .set_valid_from(1604510497000)
+        .set_valid_to(1607102497000)
         .set_confidence_score("LOW")
     )
 
     malware = (
         Entity.attribute("MALWARE", "MalwareName")
-        .set_valid_from(1604510497)
-        .set_valid_to(1607102497)
+        .set_valid_from(1604510497000)
+        .set_valid_to(1607102497000)
         .set_confidence_score("MEDIUM")
     )
     ip4 = (
         Entity.observable("IP4", "2.2.2.2")
-        .set_valid_from(1604510497)
-        .set_valid_to(1607102497)
+        .set_valid_from(1604510497000)
+        .set_valid_to(1607102497000)
         .set_confidence_score("LOW")
     )
     url = (
         Entity.observable("URL", "wwww.relatedUrl.com")
-        .set_valid_from(1604510497)
-        .set_valid_to(1607102497)
+        .set_valid_from(1604510497000)
+        .set_valid_to(1607102497000)
         .set_confidence_score("HIGH")
     )
     indicator = [
         Indicator("URL", "verybadurl")
-        .set_valid_from(1604510497)
-        .set_valid_to(1607102497)
+        .set_valid_from(1604510497000)
+        .set_valid_to(1607102497000)
         .set_confidence_score("LOW")
         .set_malicious_score("BENIGN")
         .set_attributes([threat_actor, malware])
@@ -166,7 +166,7 @@ def full_submission(submission, complex_indicator):
         .set_enclave_id("c0f07a9f-76e4-48df-a0d4-c63ed2edccf0")
         .set_external_id("external-1234")
         .set_external_url("externalUrlValue")
-        .set_timestamp(1607102497)
+        .set_timestamp(1607102497000)
         .set_tags(["random_tag"])
         .set_raw_content("blob of text")
     )

--- a/trustar2/base.py
+++ b/trustar2/base.py
@@ -13,7 +13,7 @@ def get_timestamp(date):
         date, settings={"TIMEZONE": "UTC", "RETURN_AS_TIMEZONE_AWARE": True}
     )
 
-    timestamp = (dt_obj - datetime(1970, 1, 1, tzinfo=pytz.UTC)).total_seconds()
+    timestamp = (dt_obj - datetime(1970, 1, 1, tzinfo=pytz.UTC)).total_seconds() * 1000
     return int(timestamp)
 
 


### PR DESCRIPTION
*what*: a bugfix for timestamps being sent in seconds instead of milliseconds

*why*: because it makes the search using time to not work

*how*: time * 1000