### PR TITLE
Update Deprecated Endpoint "Alter Tags"

### DIFF
--- a/tests/unit/resources.py
+++ b/tests/unit/resources.py
@@ -1,6 +1,6 @@
 indicators_example_request = """{
    "queryTerm":"/Users/mknopf/code/test.sh",
-   "enclaveIds":[
+   "enclaveGuids":[
       "3a93fab3-f87a-407a-9376-8eb3fae99b4e"
    ],
    "priorityScores":[

--- a/tests/unit/test_indicator_tags.py
+++ b/tests/unit/test_indicator_tags.py
@@ -1,0 +1,63 @@
+from __future__ import unicode_literals
+
+import pytest
+
+from trustar2.indicator_tags import TagIndicator
+from trustar2.trustar import TruStar
+
+
+@pytest.fixture
+def tag_indicator():
+    return TagIndicator(
+        TruStar(api_key="xxxx", api_secret="xxx", client_metatag="test_env")
+    )
+
+
+@pytest.mark.parametrize("added_tags,removed_tags", [(["important", "tag"], []),
+                                                     ([], ["not_important", "tag"]),
+                                                     (["important", "tag"], ["not_important"])])
+def test_ok_alter_tags(tag_indicator, mocked_request, added_tags, removed_tags):
+    expected_url = "https://api.trustar.co/api/2.0/indicators/cc12a5c6-e575-3879-8e41-2bf240cc6fce/alter-tags"
+    mocked_request.post(url=expected_url, json={})
+
+    request = (tag_indicator
+               .set_added_tags(added_tags)
+               .set_removed_tags(removed_tags)
+               .set_enclave_id("3a93fab3-f87a-407a-9376-8eb3fae99b4e")
+               .set_indicator_id("cc12a5c6-e575-3879-8e41-2bf240cc6fce")
+               )
+    request.alter_tags()
+
+    params = request.params.serialize()
+    assert params.get("enclaveGuid") == "3a93fab3-f87a-407a-9376-8eb3fae99b4e"
+    assert params.get("addedTags") == added_tags
+    assert params.get("removedTags") == removed_tags
+
+
+def test_alter_tag_incomplete(tag_indicator, mocked_request):
+    expected_url = "https://api.trustar.co/api/2.0/indicators/cc12a5c6-e575-3879-8e41-2bf240cc6fce/alter-tags"
+    mocked_request.post(url=expected_url, json={})
+
+    # Missing added/removed tags
+    with pytest.raises(AttributeError):
+        q = (tag_indicator
+             .set_enclave_ids("3a93fab3-f87a-407a-9376-8eb3fae99b4e")
+             .set_indicator_id("cc12a5c6-e575-3879-8e41-2bf240cc6fce")
+             .alter_tags()
+             )
+
+    # Missing enclave guid
+    with pytest.raises(AttributeError):
+        q = (tag_indicator
+             .set_added_tags(["tag"])
+             .set_indicator_id("cc12a5c6-e575-3879-8e41-2bf240cc6fce")
+             .alter_tags()
+             )
+
+    # Missing indicator_id
+    with pytest.raises(AttributeError):
+        q = (tag_indicator
+             .set_added_tags(["tag"])
+             .set_enclave_ids("3a93fab3-f87a-407a-9376-8eb3fae99b4e")
+             .alter_tags()
+             )

--- a/tests/unit/test_indicators.py
+++ b/tests/unit/test_indicators.py
@@ -83,7 +83,7 @@ def test_set_priority_scores_fail(search_indicator):
 def test_set_enclave_ids(search_indicator):
     search_indicator.set_enclave_ids(["TEST_ENCLAVE_ID"])
     assert len(search_indicator.params) == 1
-    assert search_indicator.params.get("enclaveIds") == ["TEST_ENCLAVE_ID"]
+    assert search_indicator.params.get("enclaveGuids") == ["TEST_ENCLAVE_ID"]
 
 
 @pytest.mark.parametrize(
@@ -183,21 +183,3 @@ def test_ok_query(search_indicator):
         .search()
     )
     assert q.params.serialize() == json.loads(indicators_example_request)
-
-
-def test_ok_tag_create(search_indicator, mocked_request):
-    # TODO refactor this
-    expected_url = "https://api.trustar.co/api/2.0/indicators/cc12a5c6-e575-3879-8e41-2bf240cc6fce/tags?tag=example"
-    mocked_request.post(url=expected_url, json={})
-    search_indicator.set_indicator_id("cc12a5c6-e575-3879-8e41-2bf240cc6fce").set_tag(
-        "example"
-    ).create_tag()
-
-
-def test_ok_tag_delete(search_indicator, mocked_request):
-    # TODO refactor this
-    expected_url = "https://api.trustar.co/api/2.0/indicators/cc12a5c6-e575-3879-8e41-2bf240cc6fce/tags?tag=example"
-    mocked_request.delete(url=expected_url)
-    search_indicator.set_indicator_id("cc12a5c6-e575-3879-8e41-2bf240cc6fce").set_tag(
-        "example"
-    ).delete_tag()

--- a/trustar2/__init__.py
+++ b/trustar2/__init__.py
@@ -4,3 +4,4 @@ from trustar2.indicators import SearchIndicator
 from trustar2.submission import Submission
 from trustar2.trustar import TruStar
 from trustar2.safelist import Safelist
+from trustar2.indicator_tags import TagIndicator

--- a/trustar2/indicator_tags.py
+++ b/trustar2/indicator_tags.py
@@ -1,0 +1,66 @@
+from __future__ import unicode_literals
+
+from .base import Methods, Param, ParamsSerializer, fluent
+from .query import Query
+
+
+@fluent
+class TagIndicator:
+    url = "/indicators"
+
+    def __init__(self, config):
+        self.config = config
+        self.params = ParamsSerializer()
+        self.endpoint = None
+
+    @property
+    def base_url(self):
+        return self.config.request_details.get("api_endpoint") + self.url
+
+    @property
+    def tag_endpoint(self):
+        if "indicator_id" not in self.params:
+            raise AttributeError(
+                "Indicator id value is required for altering tags of an indicator submission"
+            )
+        if "addedTags" not in self.params and "removedTags" not in self.params:
+            raise AttributeError(
+                "Either 'addedTags' or 'removedTags' values are required for altering tags of an indicator submission"
+            )
+        if "enclaveGuid" not in self.params:
+            raise AttributeError(
+                "Enclave id value is required for altering tags of an indicator submission"
+            )
+
+        return self.base_url + "/{}/alter-tags".format(self.params.get("indicator_id"))
+
+    def set_custom_param(self, key, value):
+        param = Param(key=key, value=value)
+        self.params.add(param)
+
+    def set_added_tags(self, added_tags):
+        if not isinstance(added_tags, list):
+            raise AttributeError(u"addedTags {} should be a list of string values".format(added_tags))
+        self.set_custom_param("addedTags", added_tags)
+
+    def set_removed_tags(self, removed_tags):
+        if not isinstance(removed_tags, list):
+            raise AttributeError(u"removed_tags {} should be a list of string values".format(removed_tags))
+        self.set_custom_param("removedTags", removed_tags)
+
+    def set_enclave_id(self, enclave_guid):
+        self.set_custom_param("enclaveGuid", enclave_guid)
+
+    def set_indicator_id(self, indicator_id):
+        self.set_custom_param("indicator_id", indicator_id)
+
+    def create_query(self, method):
+        return Query(self.config, self.endpoint, method)
+
+    def alter_tags(self):
+        self.endpoint = self.tag_endpoint
+        return (
+            self.create_query(Methods.POST)
+            .set_params(self.params)
+            .fetch_one()
+        )

--- a/trustar2/trustar_enums.py
+++ b/trustar2/trustar_enums.py
@@ -15,6 +15,11 @@ class SortColumns(TSEnum):
     UPDATED = "UPDATED"
 
 
+class SortOrder(TSEnum):
+    ASC = "ASC"
+    DESC = "DESC"
+
+
 class ObservableTypes(TSEnum):
 
     BITCOIN_ADDRESS = "BITCOIN_ADDRESS"
@@ -46,3 +51,19 @@ class TruStarUrls(TSEnum):
     API = "https://api.trustar.co/api/2.0"
     AUTH_TOKEN = "https://api.trustar.co/oauth/token"
     STATION = "https://station.trustar.co"
+
+
+@staticmethod
+def get_enum_value(arg, enum):
+    if isinstance(arg, enum):
+        return arg.value
+
+    if isinstance(arg, str) and arg in enum.members():
+        return arg
+
+    if isinstance(arg, type("")) and arg in enum.members():
+        return arg  # For py2 and py3 compatibility
+
+    raise AttributeError(
+        "Possible value types are: {}".format(list(enum.members()))
+    )

--- a/trustar2/trustar_enums.py
+++ b/trustar2/trustar_enums.py
@@ -51,19 +51,3 @@ class TruStarUrls(TSEnum):
     API = "https://api.trustar.co/api/2.0"
     AUTH_TOKEN = "https://api.trustar.co/oauth/token"
     STATION = "https://station.trustar.co"
-
-
-@staticmethod
-def get_enum_value(arg, enum):
-    if isinstance(arg, enum):
-        return arg.value
-
-    if isinstance(arg, str) and arg in enum.members():
-        return arg
-
-    if isinstance(arg, type("")) and arg in enum.members():
-        return arg  # For py2 and py3 compatibility
-
-    raise AttributeError(
-        "Possible value types are: {}".format(list(enum.members()))
-    )


### PR DESCRIPTION
**What?**

According to: https://docs.trustar.co/api/v20/index.html, the SDK was having a slightly different functionality regarding a couple of endpoints.  This PR addresses:

Search Endpoint additional parameters:
- "enclaveIds" is called "enclaveGuids" 
- sortOrder is a parameter that's available 
- includedTags and excludedTags are list parameters that are available.

The "tag indicator" functionality is different enough to move into its own class (the documentation.md file hasn't been updated yet)

**Why?**

To release with up-to-date endpoints 