### PR TITLE
[ECO-640] (Pushing Again) 💀 Create / Update Sumissions --> UPSERT 🌅 

### DIFF
--- a/trustar2/safelist.py
+++ b/trustar2/safelist.py
@@ -95,8 +95,6 @@ class Safelist(object):
     def get_safelist_libraries(self):
         """Retrieves safelist details given a library guid. 
 
-        You have to call 'set_library_guid' before calling this method.
-
         :returns: HTTP response with safelist library summaries in it's content.
         """
         return Query(self.config, self.summaries_endpoint, Methods.GET).set_params(self.params).fetch_one()

--- a/trustar2/submission.py
+++ b/trustar2/submission.py
@@ -7,29 +7,38 @@ from .query import Query
 @fluent
 class Submission(object):
 
-    NEW_SUBMISSION_MANDATORY_FIELDS = ("title", "content", "enclaveGuid")
+    SUBMISSION_MANDATORY_FIELDS = ("title", "content", "enclaveGuid")
     path = "/submissions/indicators"
 
     def __init__(self, config=None):
         self.config = config
-        self.params = ParamsSerializer()
+        self.payload_params = ParamsSerializer()
+        self.query_params = ParamsSerializer()
         for func in (self.set_tags,):
             func()
 
     def __str__(self):
         return "Submission <{}> with external Id <{}>".format(
-            self.params.get("title"), 
-            self.params.get("externalId")
+            self.payload_params.get("title"), 
+            self.payload_params.get("externalId")
         )
 
     @property
     def endpoint(self):
         return self.config.request_details.get("api_endpoint") + self.path
 
-    def set_custom_param(self, key, value):
+
+    def set_payload_param(self, key, value):
         """Adds a new param to set of params."""
         param = Param(key=key, value=value)
-        self.params.add(param)
+        self.payload_params.add(param)
+
+    
+    def set_query_param(self, key, value):
+        """Adds a new param to set of params."""
+        param = Param(key=key, value=value)
+        self.query_params.add(param)
+
 
     def set_id(self, submission_id):
         """Adds id param to set of params.
@@ -37,7 +46,9 @@ class Submission(object):
         :param submission_id: field value.
         :returns: self.
         """
-        self.set_custom_param("id", submission_id)
+        self.set_payload_param("id", submission_id)
+        self.set_query_param("id", submission_id)
+
 
     def set_title(self, title):
         """Adds title param to set of params.
@@ -45,7 +56,8 @@ class Submission(object):
         :param title: field value.
         :returns: self.
         """
-        self.set_custom_param("title", title)
+        self.set_payload_param("title", title)
+
 
     def set_content_indicators(self, indicators):
         """Adds content param to set of params.
@@ -55,7 +67,8 @@ class Submission(object):
         """
         indicators = [i.serialize() for i in indicators]
         content = {"indicators": indicators}
-        self.set_custom_param("content", content)
+        self.set_payload_param("content", content)
+
 
     def set_enclave_id(self, enclave_id):
         """Adds enclaveId param to set of params.
@@ -63,7 +76,9 @@ class Submission(object):
         :param enclave_id: field value.
         :returns: self.
         """
-        self.set_custom_param("enclaveGuid", enclave_id)
+        self.set_payload_param("enclaveGuid", enclave_id)
+        self.set_query_param("enclaveGuid", enclave_id)
+
 
     def set_external_id(self, external_id):
         """Adds externalId param to set of params.
@@ -71,7 +86,8 @@ class Submission(object):
         :param external_id: field value.
         :returns: self.
         """
-        self.set_custom_param("externalId", external_id)
+        self.set_payload_param("externalId", external_id)
+
 
     def set_external_url(self, external_url):
         """Adds externalUrl param to set of params.
@@ -79,7 +95,8 @@ class Submission(object):
         :param external_url: field value.
         :returns: self.
         """
-        self.set_custom_param("externalUrl", external_url)
+        self.set_payload_param("externalUrl", external_url)
+
 
     def set_tags(self, tags=None):
         """Adds tags param to set of params.
@@ -89,7 +106,8 @@ class Submission(object):
         """
         if not tags:
             tags = []
-        self.set_custom_param("tags", tags)
+        self.set_payload_param("tags", tags)
+
 
     def set_id_type_as_external(self, external=False):
         """Sets idType to EXTERNAL if 'external' parameter is True.
@@ -98,7 +116,8 @@ class Submission(object):
         :returns: self.
         """
         if external:
-            self.set_custom_param("idType", "EXTERNAL")
+            self.set_query_param("idType", "EXTERNAL")
+
 
     def set_include_content(self, content=False):
         """
@@ -107,7 +126,8 @@ class Submission(object):
         :param content: field value.
         :returns: self.
         """
-        self.set_custom_param("includeContent", content)
+        self.set_query_param("includeContent", content)
+
 
     def set_timestamp(self, timestamp):
         """Adds timestamp param to set of params.
@@ -118,7 +138,8 @@ class Submission(object):
         if not isinstance(timestamp, int):
             timestamp = get_timestamp(timestamp)
 
-        self.set_custom_param("timestamp", timestamp)
+        self.set_payload_param("timestamp", timestamp)
+
 
     def set_raw_content(self, raw_content):
         """Adds rawContent param to set of params.
@@ -126,7 +147,8 @@ class Submission(object):
         :param raw_content: field value.
         :returns: self.
         """
-        self.set_custom_param("rawContent", raw_content)
+        self.set_payload_param("rawContent", raw_content)
+
 
     def set_submission_version(self, version):
         """Adds submissionVersion param to set of params.
@@ -134,60 +156,66 @@ class Submission(object):
         :param version: field value.
         :returns: self.
         """
-        self.set_custom_param("submissionVersion", version)
+        self.set_payload_param("submissionVersion", version)
+
 
     def set_trustar_config(self, trustar_config):
         self.config = trustar_config
 
     @property
-    def query_params(self):
-        query_params = {
-            p.key: p.value
-            for p in self.params
-            if p.key in ("id", "idType", "enclaveGuid", "includeContent")
-        }
-
+    def query_string_params(self):
+        query_params = self.query_params.serialize()
         if self.should_use_external_id():
-            query_params["id"] = self.params.get("externalId")
+            query_params["id"] = self.payload_params.get("externalId")
 
         return query_params
 
+
     def should_use_external_id(self):
         """Returns True if params are set to retrieve a submission by external id"""
-        return "idType" in self.params and "externalId" in self.params
+        return "idType" in self.query_params and "externalId" in self.payload_params
 
-    def create_query(self, method):
+
+    def create_query(self, method, specific_endpoint=""):
         """Returns a new instance of a Query object according config, endpoint and method."""
-        return Query(self.config, self.endpoint, method)
+        endpoint = self.endpoint + specific_endpoint
+        return Query(self.config, endpoint, method)
 
-    def create(self):
-        """Creates a new submission according to params set before."""
-        for k in self.NEW_SUBMISSION_MANDATORY_FIELDS:
-            if k not in self.params:
-                raise AttributeError("{} field should be in your submission".format(k))
-        return self.create_query(Methods.POST).set_params(self.params).fetch_one()
+
+    def _raise_without_id(self):
+        if not "id" in self.query_string_params:
+            raise AttributeError(
+                "You need to set an id, or an external id marking the id type as external"
+            )
+
 
     def delete(self):
         """Deletes a submission according to query_params set before."""
+        self._raise_without_id()
         return (
             self.create_query(Methods.DELETE)
-            .set_query_string(self.query_params)
+            .set_query_string(self.query_string_params)
             .fetch_one()
         )
 
     def get(self):
         """Retrieves a submission according to query_params set before."""
+        self._raise_without_id()
         return (
             self.create_query(Methods.GET)
-            .set_query_string(self.query_params)
+            .set_query_string(self.query_string_params)
             .fetch_one()
         )
 
-    def update(self):
-        """Updates a submission according to query_params set before."""
+    def upsert(self):
+        """Update a submission if it already exists or create a new one if it doesn't."""
+        for k in self.SUBMISSION_MANDATORY_FIELDS:
+            if k not in self.payload_params:
+                raise AttributeError("{} field should be in your submission".format(k))
+
         return (
-            self.create_query(Methods.PUT)
-            .set_params(self.params)
-            .set_query_string(self.query_params)
+            self.create_query(Methods.POST, specific_endpoint="/upsert")
+            .set_params(self.payload_params)
+            .set_query_string(self.query_string_params)
             .fetch_one()
         )


### PR DESCRIPTION
**What**: Deleting create and update method for submissions as the upsert operation will take care of both.

**Why**: Changes in the API - rate limitting.

**How**: Deleting methods. And Creating new upsert one. 

_Also:_ Little refactor of `params`. Now we differentiate between query_params and payload_params while setting a new param. 

https://trustar.atlassian.net/browse/ECO-640

**This [PR](https://github.com/trustar/trustar-sdk2-proto/pull/40) was already approved but I reverted it so that I could create a new release in PyPI with my fix for the creds issue and not break TruSTASH in the process.**