### PR TITLE
[SINT-1345] Update AttributeTypes enum with CARO_MALWARE value

### DIFF
--- a/trustar2/trustar_enums.py
+++ b/trustar2/trustar_enums.py
@@ -42,7 +42,7 @@ class ObservableTypes(TSEnum):
 
 class AttributeTypes(TSEnum):
     
-    CORA_MALWARE = "CORA_MALWARE"
+    CARO_MALWARE = "CARO_MALWARE"
     CVE = "CVE"
     MALWARE = "MALWARE"
     MITRE_TACTIC = "MITRE_TACTIC"


### PR DESCRIPTION
#### `Resolves`:
- [SINT-1345](https://splunk.atlassian.net/browse/SINT-1345) **Update AttributeTypes value from CORA_MALWARE to CARO_MALWARE**

#### `Brief Description`:

**WHAT**: Updated enum value on AttributeTypes for CARO_MALWARE

**HOW**: 

- Updating enum definition of constant and its string value.

**WHY**: Previous value was CORA_MALWARE.

